### PR TITLE
Use various key states for debouncing.

### DIFF
--- a/firmware/src/Matrix.h
+++ b/firmware/src/Matrix.h
@@ -22,12 +22,22 @@ class Matrix {
     void sleep(void);
 
   private:
+
+    enum class KeyStatus {
+      NOT_PRESSED,
+      PRESSED_BOUNCING,
+      PRESSED,
+      RELEASING_BOUNCING,
+    };
+
     struct KeyState {
       uint32_t pressTime;
-      bool pressed;
+      KeyStatus status;
     };
 
     KeyState keys[(int)Dim::Row][(int)Dim::Col];
+    
+    bool updateState(const int row, const int col, const bool pressed);
 
     static const uint8_t rowPins[];
     static const uint8_t colPins[];


### PR DESCRIPTION
**Issue**

Occasional stuck keysssss.

**Cause**

Actual release being ignored as bouncing.

**Fix**

New debouncing algorithm.

**Background**

I adapted an [algorithm](https://summivox.wordpress.com/2016/06/03/keyboard-matrix-scanning-and-debouncing/) by Yin Zhong that was implemented in Stapelberg's [KinX](https://michael.stapelberg.ch/posts/2018-04-17-kinx-keyboard-controller/) controller. 

I haven't had any stuck keys yet, and latency appears to be unaffected (untested). 